### PR TITLE
Bugfix images for pages, images, descriptions.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -15,7 +15,6 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",
-  "useTabs": false,
   "embeddedLanguageFormatting": "auto",
   "vueIndentScriptAndStyle": false,
   "experimentalTernaries": false

--- a/public/api/api.ts
+++ b/public/api/api.ts
@@ -1,17 +1,17 @@
-import {ProductSpec} from '../../src/types/ProductSpec';
-import {Product} from '../../src/types/Product';
+import { ProductSpec } from '../../src/types/ProductSpec';
+import { Product } from '../../src/types/Product';
 
-const API_URL = '/public/api/';
+const API_URL = '/api/';
 
 function setWait(delay: number) {
-	return new Promise((resolve) => setTimeout(resolve, delay));
+  return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
 type item = ProductSpec | Product;
 type category = 'accessories' | 'phones' | 'products' | 'tablets';
 
 export async function getProductList(category: category): Promise<item[]> {
-	return setWait(1000)
-		.then(() => fetch(API_URL + `${category}.json`))
-		.then((response) => response.json());
+  return setWait(1000)
+    .then(() => fetch(API_URL + `${category}.json`))
+    .then((response) => response.json());
 }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -32,6 +32,11 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
 
   const added = useAppSelector((state) => state.cartProducts.cartProducts);
 
+  // if (!product || !product.image) {
+  //   console.error('Product or product.image is missing:', product);
+  //   return null;
+  // }
+
   const addToCart = (product: Product) => dispatch(increaseQuantity(product));
 
   const addToFavorite = () => {
@@ -48,21 +53,26 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
     }
   };
 
+  const correctedImagePath = product.image
+    ? product.image.startsWith('/')
+      ? product.image
+      : `/${product.image}`
+    : '/img/phones/apple-iphone-7/black/00.webp';
+
   return (
     <div className={styles.product_card}>
       <img
         className={styles.product_card__image}
-        src={product.image}
+        src={correctedImagePath}
         alt={`${product.name} Image`}
       />
-
+      console.log('Product Image Path:', `/${product.image}`);
       <Link
         to={`/${product.category}/${product.id}`}
         className={styles.product_card__name}
       >
         {product.name}
       </Link>
-
       <div className={styles.product_card__price}>
         {product.priceDiscount ? (
           <>
@@ -79,9 +89,7 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
           </span>
         )}
       </div>
-
       <div className={styles.product_card__separator}></div>
-
       <div className={styles.product_card__features}>
         <div className={styles.product_card__feature}>
           <div className={styles.product_card__feature_label}>Screen:</div>
@@ -104,7 +112,6 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
           </div>
         </div>
       </div>
-
       <div className={styles.product_card__actions}>
         <button
           onClick={onAddToCart}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -32,11 +32,6 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
 
   const added = useAppSelector((state) => state.cartProducts.cartProducts);
 
-  // if (!product || !product.image) {
-  //   console.error('Product or product.image is missing:', product);
-  //   return null;
-  // }
-
   const addToCart = (product: Product) => dispatch(increaseQuantity(product));
 
   const addToFavorite = () => {
@@ -53,20 +48,13 @@ export const Card: React.FC<CardItemProps> = ({ product }) => {
     }
   };
 
-  const correctedImagePath = product.image
-    ? product.image.startsWith('/')
-      ? product.image
-      : `/${product.image}`
-    : '/img/phones/apple-iphone-7/black/00.webp';
-
   return (
     <div className={styles.product_card}>
       <img
         className={styles.product_card__image}
-        src={correctedImagePath}
+        src={product.images[0]}
         alt={`${product.name} Image`}
       />
-      console.log('Product Image Path:', `/${product.image}`);
       <Link
         to={`/${product.category}/${product.id}`}
         className={styles.product_card__name}

--- a/src/components/CartItem/CartItem.tsx
+++ b/src/components/CartItem/CartItem.tsx
@@ -32,11 +32,11 @@ export const CartItem: React.FC<Props> = ({ item }) => {
       <button className={styles.cart__item__icon__close} onClick={handleRemove}>
         <img src='/img/icons/Close.svg' alt='Close' />
       </button>
-      {/* <img
-        src={item.image[0]}
+      <img
+        src={item.images[0]}
         alt={`${item.name} Image`}
         className={styles.cart__item__image}
-      /> */}
+      />
       <div className={styles.cart__item__description}>
         <Link
           to={`/${item.category}/${item.id}`}

--- a/src/components/SearchField/SearchField.module.scss
+++ b/src/components/SearchField/SearchField.module.scss
@@ -38,7 +38,7 @@ body:has(.slideDown) {
   
 //for the future dark mode
   &.dark {
-    background-image: url('../../assets/icons/search_icons/search-alt-2darkMode.svg');
+    background-image: url(../../assets/icons/search_icons/search-alt-2darkMode.svg);
   }
 
   &:hover {

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './SearchField.module.scss';
 import { Product } from '../../types/Product';
-import { getProducts } from '../../components/api/apiE';
+import { getProductList } from '../../public-copy/api/api';
 import { Link, useParams } from 'react-router-dom';
 import { RoutesPathes } from '../../utils/RoutesPathes';
 import { ProductCategories } from '../../utils/ProductCategories';
@@ -34,14 +34,16 @@ export const SearchField: React.FC = () => {
   const fetchProducts = (query: string) => {
     const preparedQuery = query.trim().toLowerCase();
 
-    getProducts().then((productsFromServer) => {
-      const filteredProducts = productsFromServer.filter(
-        (product: Product) =>
-          preparedQuery !== '' &&
-          product.name.toLowerCase().includes(preparedQuery)
-      );
-      setProducts(filteredProducts);
-    });
+    getProductList(ProductCategories.PHONES).then(
+      (productsFromServer: Product[]) => {
+        const filteredProducts = productsFromServer.filter(
+          (product: Product) =>
+            preparedQuery !== '' &&
+            product.name.toLowerCase().includes(preparedQuery)
+        );
+        setProducts(filteredProducts);
+      }
+    );
   };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const fetchProductsWithDelay = useCallback(debounce(fetchProducts, 500), [
@@ -100,7 +102,7 @@ export const SearchField: React.FC = () => {
       >
         <div>
           <img
-            src={product.image}
+            src={product.images[0]}
             alt={product.name}
             className={styles.image}
           />

--- a/src/pages/AccessoriesPage/AccessoriesPage.tsx
+++ b/src/pages/AccessoriesPage/AccessoriesPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Catalog } from '../../components/Catalog/Catalog';
-import { getAccessories } from '../../components/api/apiE';
+// import React from 'react';
+// import { Catalog } from '../../components/Catalog/Catalog';
+// import { getAccessories } from '../../components/api/apiE';
 
-export const AccessoriesPage: React.FC = () => {
-  return <Catalog fetchProducts={getAccessories} title='Accessories' />;
-};
+// export const AccessoriesPage: React.FC = () => {
+//   return <Catalog fetchProducts={getAccessories} title='Accessories' />;
+// };

--- a/src/pages/PhonesPage/PhonesPage.tsx
+++ b/src/pages/PhonesPage/PhonesPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Catalog } from '../../components/Catalog/Catalog';
-import { getPhones } from '../../components/api/apiE';
+// import React from 'react';
+// import { Catalog } from '../../components/Catalog/Catalog';
+// import { getPhones } from '../../components/api/apiE';
 
-export const PhonesPage: React.FC = () => {
-  return <Catalog fetchProducts={getPhones} title='Phones' />;
-};
+// export const PhonesPage: React.FC = () => {
+//   return <Catalog fetchProducts={getPhones} title='Phones' />;
+// };

--- a/src/pages/PhonesPage/PhonesPage.tsx
+++ b/src/pages/PhonesPage/PhonesPage.tsx
@@ -1,7 +1,7 @@
-// import React from 'react';
-// import { Catalog } from '../../components/Catalog/Catalog';
-// import { getPhones } from '../../components/api/apiE';
+import React from 'react';
+import { Catalog } from '../../components/Catalog/Catalog';
+import { getPhones } from '../../components/api/apiE';
 
-// export const PhonesPage: React.FC = () => {
-//   return <Catalog fetchProducts={getPhones} title='Phones' />;
-// };
+export const PhonesPage: React.FC = () => {
+  return <Catalog fetchProducts={getPhones} title='Phones' />;
+};

--- a/src/pages/TabletsPage/TabletsPage.tsx
+++ b/src/pages/TabletsPage/TabletsPage.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Catalog } from '../../components/Catalog/Catalog';
-import { getTablets } from '../../components/api/apiE';
+// import React from 'react';
+// import { Catalog } from '../../components/Catalog/Catalog';
+// import { getTablets } from '../../components/api/apiE';
 
-export const TabletsPage: React.FC = () => {
-  return <Catalog fetchProducts={getTablets} title='Tablets' />;
-};
+// export const TabletsPage: React.FC = () => {
+//   return <Catalog fetchProducts={getTablets} title='Tablets' />;
+// };

--- a/src/public-copy/api/api.ts
+++ b/src/public-copy/api/api.ts
@@ -1,5 +1,6 @@
 // import { ProductSpec } from '../../types/ProductSpec';
 import { Product } from '../../types/Product';
+import { ProductCategories } from '../../utils/ProductCategories';
 
 const API_URL = '/api/';
 
@@ -13,9 +14,11 @@ function processScreenInfo(screen: string): string {
 }
 
 type item = Product;
-type category = 'accessories' | 'phones' | 'products' | 'tablets';
+// type category = 'accessories' | 'phones' | 'products' | 'tablets';
 
-export async function getProductList(category: category): Promise<item[]> {
+export async function getProductList(
+  category: ProductCategories
+): Promise<item[]> {
   return setWait(100)
     .then(() => fetch(API_URL + `${category}.json`))
     .then((response) => response.json())

--- a/src/public-copy/api/api.ts
+++ b/src/public-copy/api/api.ts
@@ -7,11 +7,24 @@ function setWait(delay: number) {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
+function processScreenInfo(screen: string): string {
+  const parts = screen.split('(');
+  return parts[0];
+}
+
 type item = Product;
 type category = 'accessories' | 'phones' | 'products' | 'tablets';
 
 export async function getProductList(category: category): Promise<item[]> {
   return setWait(100)
     .then(() => fetch(API_URL + `${category}.json`))
-    .then((response) => response.json());
+    .then((response) => response.json())
+    .then((products) => {
+      return products.map((product: Product) => {
+        if (product.screen) {
+          product.screen = processScreenInfo(product.screen);
+        }
+        return product;
+      });
+    });
 }

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -12,6 +12,6 @@ export interface Product {
   color: string;
   ram: string;
   year: number;
-  image: string;
+  images: string[];
   quantity: number;
 }

--- a/src/types/ProductSpec.ts
+++ b/src/types/ProductSpec.ts
@@ -4,7 +4,7 @@ export interface ProductDescription {
 }
 
 export interface ProductSpec {
-  id: string;
+  id?: string;
   category: string;
   namespaceId: string;
   name: string;
@@ -14,9 +14,9 @@ export interface ProductSpec {
   priceDiscount?: number;
   colorsAvailable: string[];
   color: string;
-  images: string[];
+  image: string[];
   description: ProductDescription[];
-  screen: string;
+  screen?: string;
   resolution: string;
   processor: string;
   ram: string;

--- a/src/utils/ProductCategories.ts
+++ b/src/utils/ProductCategories.ts
@@ -2,4 +2,5 @@ export enum ProductCategories {
   PHONES = 'phones',
   TABLETS = 'tablets',
   ACCESSORIES = 'accessories',
+  PRODUCTS = 'products',
 }


### PR DESCRIPTION
1. Images are now working in Pages, Cart;
2.  **If we are declaring types with TypeScript** (source: web):
How to name an array of images?
•	`images` is the most intuitive and common name for an array, as it clearly indicates a collection of images.
•	`image` can also work, but it might be confusing since the singular form typically refers to one object.

Conclusion:
While you can technically use `image`, it’s better to use `images` for arrays to follow common practices and improve readability.

3. Fix the long description for `screen` spec on Product Cards  using the `split` method ( by '(' symbol ) because the API parsing works for all categories and didn't match the data for screen from `products.json` ( since 'phones' appears as the category in both JSON files - `phones.json` & `products.json`)